### PR TITLE
json_ingest 3.0.0rc1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,10 @@
 
 ### FEATURE OWNERSHIPS ###
 
+/selfscape_insight/features/sample.py @duggann4
 /selfscape_insight/features/feelings.py @Peter-Hafner
 /selfscape_insight/features/topics.py @jacobs81
 /selfscape_insight/features/ip_loc.py @TREVORLE123
 
 /selfscape_insight/readers/ @duggann4
+/selfscape_insight/core/json_handling.py @duggann4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,22 +20,22 @@ maintainers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pyarrow",
-    "pandas",
-    "geopandas",
-    "requests",
-    "maxminddb",
-    "beautifulsoup4",
-    "matplotlib",
-    "spacy",
-    "spacytextblob",
-    "wordcloud",
-    "plotly",
-    "nbformat",
-    "folium",
-    "seaborn",
-    "pillow",
-    "tqdm"
+    "pyarrow >=15.0.2",
+    "pandas >=2.2.1",
+    "geopandas >=0.14.3",
+    "requests >=2.31.0",
+    "maxminddb >=2.6.0",
+    "beautifulsoup4 >=4.12.3",
+    "matplotlib >=3.8.4",
+    "spacy >=3.7.4",
+    "spacytextblob >=4.0.0",
+    "wordcloud >=1.9.3",
+    "plotly >=5.20.0",
+    "nbformat >=5.10.4",
+    "folium >=0.16.0",
+    "seaborn >=0.13.2",
+    "pillow >=10.3.0",
+    "tqdm >=4.66.2"
 ]
 classifiers = [
     "Private :: Do Not Upload",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pandas",
     "geopandas",
     "requests",
-    "flatsplode",
     "maxminddb",
     "beautifulsoup4",
     "matplotlib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ pyarrow
 pandas
 geopandas
 requests
-flatsplode
 maxminddb
 beautifulsoup4
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-pyarrow
-pandas
-geopandas
-requests
-maxminddb
-beautifulsoup4
-matplotlib
-spacy
-spacytextblob
-wordcloud
-plotly
-nbformat
-folium
-seaborn
-pillow
-tqdm
+pyarrow >=15.0.2
+pandas >=2.2.1
+geopandas >=0.14.3
+requests >=2.31.0
+maxminddb >=2.6.0
+beautifulsoup4 >=4.12.3
+matplotlib >=3.8.4
+spacy >=3.7.4
+spacytextblob >=4.0.0
+wordcloud >=1.9.3
+plotly >=5.20.0
+nbformat >=5.10.4
+folium >=0.16.0
+seaborn >=0.13.2
+pillow >=10.3.0
+tqdm >=4.66.2

--- a/selfscape_insight/features/sample.py
+++ b/selfscape_insight/features/sample.py
@@ -9,28 +9,27 @@ Functions:
 
 Example usage:
     >>> import sample_feature as sf
-    >>> sf.run(JsonReader.get_csv("bcts"))
+    >>> sf.run(JsonReader.get_pkl("bcts"))
     There are X advertising-related topics in the profile!
     Go do more interesting things...
 
-    $ python3 sample_feature.py -bcts /path/to/bcts.csv
+    $ python3 sample_feature.py -bcts /path/to/bcts.pkl
     There are X advertising-related topics in the profile!
     Go do more interesting things...
 
 Dependencies:
-    Pandas package for data handling.
+    No external dependencies.
 
 Note:
     This sub-module is part of the 'selfscape_insight' package in the 'feature' module.
 
 Version:
-    1.0
+    2.0
 
 Author:
     Noah Duggan Erickson
 """
 
-import pandas as pd
 import argparse
 
 def run(bcts):
@@ -40,7 +39,7 @@ def run(bcts):
     (This description should be more verbose in a real feature!)
 
     Args:
-        bcts (str): path to csv file specified by the parameter name
+        bcts (str): path to pkl file specified by the parameter name
     
     Returns:
         str: This feature's contribution to the profile info dashboard datavis thing
@@ -49,8 +48,7 @@ def run(bcts):
         run() is a *required* function for the module! It *must*
         be the only interaction that main.py has with the module.
     """
-    df = pd.read_csv(bcts)
-    return f"There are {len(df)} advertising-related topics in the profile!\nGo do more interesting things..."
+    return f"There are {len(bcts)} advertising-related topics in the profile!\nGo do more interesting things..."
 
 # Below is more-or-less boilerplate code that can be copy/pasted
 # and extended to allow the feature to run directly from the
@@ -58,6 +56,6 @@ def run(bcts):
 #
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog='sample_feature', description='A sample program feature for the purposes of demo-ing code structure and boilerplate')
-    parser.add_argument('-bcts', metavar='BCTS_CSV', help='path to bcts (ad topics) csv file', required=True)
+    parser.add_argument('-bcts', metavar='BCTS_PKL', help='path to bcts (ad topics) pkl file', required=True)
     args = parser.parse_args()
     print(run(args.bcts))

--- a/selfscape_insight/main_cli.py
+++ b/selfscape_insight/main_cli.py
@@ -103,7 +103,7 @@ def main():
     
 
     if not args.csv:
-        fileHandler = JsonReader(args.in_path, logger=logger.getChild("json"), auditor=auditor.getChild("json"))
+        fileHandler = JsonReader(args.in_path, logger=logger.getChild("pkl"), auditor=auditor.getChild("pkl"))
     else:
         fileHandler = CsvReader(args.in_path)
     featOuts = []
@@ -112,7 +112,7 @@ def main():
     #
     if mods['smp']:
         try:
-            featOuts.append(sf.run(fileHandler.get_csv("bcts")))
+            featOuts.append(sf.run(fileHandler.get_pkl("bcts")))
         except KeyError:
             logger.error("One of the files for the sample module does not exist! Skipping...")
     else:
@@ -122,7 +122,7 @@ def main():
     #
     if mods['ipl']:
         try:
-            featOuts.append(ipl.run(fileHandler.get_csv("account_activity_v2")))
+            featOuts.append(ipl.run(fileHandler.get_pkl("account_activity_v2")))
         except KeyError:
             logger.error("One of the files for the ip_loc module does not exist! Skipping...")
     else:
@@ -132,7 +132,7 @@ def main():
     #
     if mods['ofa']:
         try:
-            featOuts.append(ofa.run(fileHandler.get_csv("off_facebook_activity_v2")))
+            featOuts.append(ofa.run(fileHandler.get_pkl("off_facebook_activity_v2")))
         except KeyError:
             logger.error("One of the files for the off_fb_act module does not exist! Skipping...")
     else:
@@ -142,8 +142,8 @@ def main():
     #
     if mods['tps']:
         try:
-            featOuts.append(tps.run(fileHandler.get_csv("topics_v2"),
-                                fileHandler.get_csv("inferred_topics_v2")))
+            featOuts.append(tps.run(fileHandler.get_pkl("topics_v2"),
+                                fileHandler.get_pkl("inferred_topics_v2")))
         except KeyError:
             logger.error("One of the files for the topics module does not exist! Skipping...")
     else:

--- a/selfscape_insight/readers/json_ingest.py
+++ b/selfscape_insight/readers/json_ingest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-""" JSON Reader
+''' JSON Reader
 WWU Facebook Data Science Project
 Winter/Spring 2024
 
@@ -14,7 +14,7 @@ Examples:
     Accessing via another script/module::
 
         >>> from json_ingest import JsonReader
-        >>> reader = JsonReader("/path/to/json_root")
+        >>> reader = JsonReader('/path/to/json_root')
 
 Dependencies:
     tqdm for pretty progress bars
@@ -30,7 +30,7 @@ Version:
 
 Author:
     Noah Duggan Erickson
-"""
+'''
 
 __version__ = '3.0.0rc1'
 
@@ -60,12 +60,12 @@ from tqdm import tqdm
 
 # If running from the commandline, add the parent directory to the path
 #
-if __name__ == "__main__":
+if __name__ == '__main__':
     current_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(current_dir)
     sys.path.append(parent_dir)
 
-from core import json_handling as jh
+from core import json_handling as jh # pylint: disable=wrong-import-position
 
 # CHANGELOG:
 #   3.0.0rc1: (18 April 2024)
@@ -85,7 +85,7 @@ from core import json_handling as jh
 #     - Added docstrings, general cleaning
 #   2.1: (7 March 2024)
 #     - Refactored helpers into core package
-#     - Major refactoring to align with OOP "general idea"
+#     - Major refactoring to align with OOP 'general idea'
 #     - argparse improvements
 #     - logging QoL improvements
 #     - removed development-residual code, general cleaning
@@ -114,16 +114,19 @@ Default is 4GB. Use x*10**9 for xGB, x*10**6 for xMB.
 '''
 
 class JsonReader:
-    """
-    A class used to read JSON files from a specified directory, and convert them into PKL files.
+    '''
+    A class used to read JSON files from a specified directory,
+    and convert them into PKL files.
 
     Attributes:
         No public attributes.
-    """
+    '''
 
-    def __init__(self, jsonroot:str, pklroot:str='temp', read_messages:bool=False, dev:bool=False,
-                 logger:logging.Logger=logging.getLogger(__name__), auditor:logging.Logger=logging.getLogger('jsonAuditor')):
-        """
+    def __init__(self, jsonroot:str, pklroot:str='temp',
+                 read_messages:bool=False, dev:bool=False,
+                 logger:logging.Logger=logging.getLogger(__name__),
+                 auditor:logging.Logger=logging.getLogger('jsonAuditor')):
+        '''
         Initializes the JsonReader with paths and logging settings.
 
         Args:
@@ -134,13 +137,13 @@ class JsonReader:
             ch (logging.StreamHandler, optional): The logging stream handler. If None, a new one is created.
 
         Prints the start message with configuration details.
-        """
+        '''
 
         self._pkls = {}
         self._logger = logger
         self._auditor = auditor
         self._dev = dev
-        self._logger.info(f"\n--------\nSTARTING JSON -> JSB INGEST {__version__}\n  json path: {jsonroot}\n  dest path: {pklroot} \n    (exists? {os.path.exists(pklroot)})\n  skip msgs: {not read_messages}\n  lgng levl: {self._logger.level}\n--------") # pylint: disable=line-too-long
+        self._logger.info(f'\n--------\nSTARTING JSON -> JSB INGEST {__version__}\n  json path: {jsonroot}\n  dest path: {pklroot} \n    (exists? {os.path.exists(pklroot)})\n  skip msgs: {not read_messages}\n  lgng levl: {self._logger.level}\n--------') # pylint: disable=line-too-long
 
         paths = self._enum_json(jsonroot, not read_messages)
 
@@ -154,35 +157,35 @@ class JsonReader:
             else:
                 objs[data[0]] = data[1]
 
-        self._temp = (pklroot == 'temp')
+        self._temp = pklroot == 'temp'
         self._path = pathlib.Path(tempfile.mkdtemp() if self._temp else pklroot)
 
         if self._temp:
-            self._auditor.info(f"Temp directory created at {self._path}")
+            self._auditor.info(f'Temp directory created at {self._path}')
         elif not self._path.exists():
             self._path.mkdir()
-            self._auditor.info(f"Created directory {self._path}")
-        
+            self._auditor.info(f'Created directory {self._path}')
+
         # This is where json -> pkl conversion happens.
         # Everything above this point is json objects.
         #
         if dev:
             for obj in tqdm(objs.items(), desc='writing jsons'):
-                p = os.path.join(self._path, f"{obj[0]}.json")
+                p = os.path.join(self._path, f'{obj[0]}.json')
                 with open(p, 'w', encoding='utf-8') as file:
                     json.dump(obj[1], file)
-                self._auditor.debug(f" Created {p}")
+                self._auditor.debug(f' Created {p}')
                 self._pkls[obj[0]] = p
         else:
             for obj in tqdm(objs.items(), desc='writing pkls'):
-                p = os.path.join(self._path, f"{obj[0]}.pkl")
+                p = os.path.join(self._path, f'{obj[0]}.pkl')
                 with open(p, 'wb') as file:
                     pickle.dump(obj[1], file)
-                self._auditor.debug(f" Created {p}")
+                self._auditor.debug(f' Created {p}')
                 self._pkls[obj[0]] = p
-    
+
     def _enum_json(self, rootpath:str, ignore_messages:bool) -> list:
-        """
+        '''
         Enumerates JSON files in the specified directory, optionally ignoring the messages folder(s).
 
         This method uses the `json_handling.enum_files` function to enumerate all
@@ -197,18 +200,18 @@ class JsonReader:
 
         Returns:
             list: A list of paths to the enumerated JSON files.
-        """
+        '''
         tracemalloc.start()
         start = time.time()
         paths = jh.enum_files(rootpath, blacklist=(['messages'] if ignore_messages else []), logger=self._logger)
         end = time.time()
         c, p = tracemalloc.get_traced_memory()
-        self._logger.info(f"Enumerated {len(paths)} files in {round((end-start) * 10**3, 3)} ms and used a peak of {round(p * 10**-6, 3)}MB RAM (Current: {round(c * 10**-6, 3)}MB)") # pylint: disable=line-too-long
+        self._logger.info(f'Enumerated {len(paths)} files in {round((end-start) * 10**3, 3)} ms and used a peak of {round(p * 10**-6, 3)}MB RAM (Current: {round(c * 10**-6, 3)}MB)') # pylint: disable=line-too-long
         tracemalloc.stop()
         return paths
-    
+
     def _read_json(self, path:tuple) -> tuple:
-        """
+        '''
         Reads and processes a JSON file from the given path, converting it into a dict/list.
 
         This method attempts to process a JSON file into a pandas DataFrame by using the
@@ -222,7 +225,7 @@ class JsonReader:
 
         Returns:
             tuple: A tuple containing the name of the obj (as a string) and the obj itself.
-        """
+        '''
         out = None
         start = time.time()
         tracemalloc.start()
@@ -230,14 +233,14 @@ class JsonReader:
         end = time.time()
         c, p = tracemalloc.get_traced_memory()
         fp = os.path.join(path[0], path[1])
-        self._logger.debug(f"Processed {out[0]} ({round(os.path.getsize(fp) * 10**-6, 3)}MB) in {round((end-start) * 10**3, 3)} ms using {round(c * 10**-6, 3)}MB RAM (peak: {round(p * 10**-6, 3)}MB)") # pylint: disable=line-too-long
+        self._logger.debug(f'Processed {out[0]} ({round(os.path.getsize(fp) * 10**-6, 3)}MB) in {round((end-start) * 10**3, 3)} ms using {round(c * 10**-6, 3)}MB RAM (peak: {round(p * 10**-6, 3)}MB)') # pylint: disable=line-too-long
         if p >= RAMWARN:
-            self._logger.warning(f"HIGH RAM USAGE! Peaked at {round(p * 10**-9, 3)}GB")
+            self._logger.warning(f'HIGH RAM USAGE! Peaked at {round(p * 10**-9, 3)}GB')
         tracemalloc.stop()
         return out
 
     def get_pkl(self, name:str):
-        """
+        '''
         Returns human JSON object from PKL of specified name.
 
         Args:
@@ -248,12 +251,12 @@ class JsonReader:
 
         Raises:
             KeyError: If no JSB file with the given name exists.
-        """
+        '''
         if name not in self._pkls.keys():
-            self._logger.error(f"pkl '{name}' does not exist!")
-            self._logger.error("Please report this error if you believe this file should exist!")
-            raise KeyError(f"pkl '{name}' does not exist!")
-        self._auditor.info(f"Retrieved {name}")
+            self._logger.error(f'pkl "{name}" does not exist!')
+            self._logger.error('Please report this error if you believe this file should exist!')
+            raise KeyError(f'pkl "{name}" does not exist!')
+        self._auditor.info(f'Retrieved {name}')
         path = self._pkls[name]
         if self._dev:
             with open(path, 'r', encoding='utf-8') as file:
@@ -262,7 +265,7 @@ class JsonReader:
             return pickle.load(file)
 
     def get_names(self) -> list:
-        """
+        '''
         Returns a list of the names of all JSB files generated by the JsonReader.
 
         This method allows for easy access to the names of all JSB files that have
@@ -271,11 +274,11 @@ class JsonReader:
 
         Returns:
             list: A list of strings, each representing the name of a generated JSON file.
-        """
+        '''
         return list(self._pkls.keys())
-    
+
     def key_info(self, key:str, indent=2) -> str:
-        """
+        '''
         Provides detailed information about a specific JSB file identified by its key.
 
         This method reads the JSB file corresponding to the provided key, calculates
@@ -290,34 +293,33 @@ class JsonReader:
 
         Raises:
             KeyError: If the specified key does not correspond to any existing JSB file.
-        """
+        '''
         if key not in self._pkls.keys():
-            self._logger.error(f"{key} does not exist")
-            raise KeyError(f"{key} does not exist")
-        
-        data = self.get_pkl(key)
-        self._auditor.info(f"Retrieved info for {key}")
+            self._logger.error(f'{key} does not exist')
+            raise KeyError(f'{key} does not exist')
 
-        return f"{key}:\n{' ' * indent}RAM: {sys.getsizeof(data) * 10**-3}KB\n{' ' * indent}structure:{jh.desc_json(data, indent=indent+2)}"
-    
+        data = self.get_pkl(key)
+        self._auditor.info(f'Retrieved info for {key}')
+
+        return f'{key}:\n{' ' * indent}RAM: {sys.getsizeof(data) * 10**-3}KB\n{' ' * indent}structure:{jh.desc_json(data, indent=indent+2)}'
+
     def close(self, force:bool=False):
-        """
+        '''
         Cleans up by deleting temporary PKL files, if applicable.
 
         This method is responsible for deleting any temporary JSB files created
         during the JsonReader's operation. It is typically called when the
         JsonReader instance is no longer needed, to ensure that no unnecessary
         files are left on the filesystem.
-        """
+        '''
         if self._temp or force:
             shutil.rmtree(self._path)
-            self._auditor.info(f"Deleted directory {self._path}")
+            self._auditor.info(f'Deleted directory {self._path}')
             self._pkls = {}
             self._path = None
 
-    
     def __str__(self) -> str:
-        """
+        '''
         Returns a string representation of the JsonReader instance, listing all JSBs managed by it.
 
         This method provides an overview of the JSB files that have been generated by this instance,
@@ -326,15 +328,15 @@ class JsonReader:
 
         Returns:
             str: A formatted string containing an overview of the JSON files managed by the JsonReader.
-        """
-        out = "--------\nJSONS:"
+        '''
+        out = '--------\nJSONS:'
         for k in self._pkls.keys():
-            out += f"\n  {self.key_info(k, 4)}"
-        out += "\n--------"
-        self._auditor.info("Retrieved info for all keys")
+            out += f'\n  {self.key_info(k, 4)}'
+        out += '\n--------'
+        self._auditor.info('Retrieved info for all keys')
         return out
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='json_ingest',
                                      description='Loads and consolidates JSON files',
                                      epilog='(C) 2024 Noah Duggan Erickson, License: GNU AGPL-3.0'
@@ -349,7 +351,7 @@ if __name__ == "__main__":
                         help='path to root of JSB output data (default: temp)')
     parser.add_argument('-m', '--read_messages',
                         action='store_true', dest='m',
-                        help="If present, don't skip the messages folder - may take significantly longer to run")
+                        help='If present, don\'t skip the messages folder - may take significantly longer to run')
     parser.add_argument('-v', '--verbose',
                         action='count', dest='v', default=0,
                         help='Set stdout verbosity level (-v, -vv)')
@@ -369,10 +371,10 @@ if __name__ == "__main__":
             level = logging.DEBUG
 
     ch = logging.StreamHandler()
-    logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=level, handlers=[ch])
+    logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=level, handlers=[ch])
     w = max((len(__version__)+3), 20)
-    print("JSON -> PKL INGESTER".center(w))
-    print(f"V. {__version__}".center(w), "\n")
+    print('JSON -> PKL INGESTER'.center(w))
+    print(f'V. {__version__}'.center(w), '\n')
     reader = JsonReader(jsonroot=args.json_root, pklroot=args.jsb_root,
                         read_messages=args.m, dev=args.x,
                         logger=logging.getLogger())

--- a/selfscape_insight/readers/old_json_ingest.py
+++ b/selfscape_insight/readers/old_json_ingest.py
@@ -1,14 +1,27 @@
 # -*- coding: utf-8 -*-
-""" JSON Reader
+
+###################################################################
+###                     DEPRECATION NOTICE                      ###
+###-------------------------------------------------------------###
+###  As of 17 April 2024, this version of json_ingest has been  ###
+### deprecated. This file serves solely as a reference for the  ###
+### original 2.x implementation of the JSON -> CSV converter in ###
+###           case it is useful to future developers.           ###
+###################################################################
+""" JSON -> CSV converter
 WWU Facebook Data Science Project
 Winter/Spring 2024
 
-New docstring coming soon!
+This module reads the data provided by the Facebook GDPR data download
+and converts it into CSV files via Pandas dataframes. If the module
+is run from the commandline, the user is able to specify the directory
+where the CSV files will be written. Otherwise, the CSVs are written
+to the temp directory.
 
 Examples:
     Running from the command line::
 
-        $ python3 json_ingest.py -i /path/to/json_root
+        $ python3 json_ingest.py -i /path/to/json_root -o /where/to/write/csvs
         $ python3 json_ingest.py -h (for commandline help)
     
     Accessing via another script/module::
@@ -17,6 +30,7 @@ Examples:
         >>> reader = JsonReader("/path/to/json_root")
 
 Dependencies:
+    Pandas for general data handling
     tqdm for pretty progress bars
 
 Todo:
@@ -26,41 +40,31 @@ Todo:
     * Logging QoL improvements
 
 Version:
-    3.0.0rc1
+    2.3.1
 
 Author:
     Noah Duggan Erickson
 """
 
-__version__ = '3.0.0rc1'
+__version__ = '2.3.1'
 
-### 3.0.0rc1 LIST OF CHANGES:
-### Changed from CSVs as output filetype to pickles (PKLs)
-### Changes to JsonReader class I/O:
-###   - attr csvs now private
-###   - attr path now private
-###   - func read_json now private
-###   - func enum_json now private
-###   - rename func get_csv -> get_pkl
-###   - func get_pkl now returns JSON object (list or dict) instead of path
-### TODO: Update docstrings, clean up code, update examples
 import argparse
 import logging
 import time
 import tracemalloc
 import os
-import sys
 import tempfile
 import shutil
 import pathlib
-import json
-import pickle
+from warnings import warn
 
+import pandas as pd
 from tqdm import tqdm
 
 # If running from the commandline, add the parent directory to the path
 #
 if __name__ == "__main__":
+    import sys
     current_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(current_dir)
     sys.path.append(parent_dir)
@@ -68,10 +72,6 @@ if __name__ == "__main__":
 from core import json_handling as jh
 
 # CHANGELOG:
-#   3.0.0rc1: (18 April 2024)
-#     - Major refactor away from CSV stuff
-#     - Transition to PKLs
-#     - Refer to detailed list of changes above imports.
 #   2.3.1: (15 April 2024)
 #     - Hotfix for issues with internal imports
 #     - Removal of timeout decorator due to OS issues
@@ -115,20 +115,23 @@ Default is 4GB. Use x*10**9 for xGB, x*10**6 for xMB.
 
 class JsonReader:
     """
-    A class used to read JSON files from a specified directory, and convert them into PKL files.
+    A class used to read JSON files from a specified directory, convert them into
+    pandas DataFrames, and then write those DataFrames to CSV files in a specified
+    output directory.
 
     Attributes:
-        No public attributes.
+        csvs (dict): A dictionary mapping CSV filenames to their paths.
+        path (str): The path to the directory where the CSV files are written.
     """
 
-    def __init__(self, jsonroot:str, pklroot:str='temp', read_messages:bool=False, dev:bool=False,
+    def __init__(self, jsonroot:str, csvroot:str='temp', read_messages:bool=False,
                  logger:logging.Logger=logging.getLogger(__name__), auditor:logging.Logger=logging.getLogger('jsonAuditor')):
         """
         Initializes the JsonReader with paths and logging settings.
 
         Args:
             jsonroot (str): The root directory where the JSON files are located.
-            pklroot (str, optional): The directory where the JSB files will be written. Defaults to 'temp'.
+            csvroot (str, optional): The directory where the CSV files will be written. Defaults to 'temp'.
             read_messages (bool, optional): Flag to indicate whether to read messages. Defaults to False.
             loglevel (int, optional): The logging level. Defaults to logging.ERROR.
             ch (logging.StreamHandler, optional): The logging stream handler. If None, a new one is created.
@@ -136,63 +139,50 @@ class JsonReader:
         Prints the start message with configuration details.
         """
 
-        self._pkls = {}
+        self.csvs = {}
         self._logger = logger
         self._auditor = auditor
-        self._dev = dev
-        self._logger.info(f"\n--------\nSTARTING JSON -> JSB INGEST {__version__}\n  json path: {jsonroot}\n  dest path: {pklroot} \n    (exists? {os.path.exists(pklroot)})\n  skip msgs: {not read_messages}\n  lgng levl: {self._logger.level}\n--------") # pylint: disable=line-too-long
+        self._logger.info(f"\n--------\nSTARTING JSON -> CSV INGEST {__version__}\n  json path: {jsonroot}\n  dest path: {csvroot} \n    (exists? {os.path.exists(csvroot)})\n  skip msgs: {not read_messages}\n  lgng levl: {self._logger.level}\n--------") # pylint: disable=line-too-long
 
-        paths = self._enum_json(jsonroot, not read_messages)
+        paths = self.enum_json(jsonroot, not read_messages)
 
-        objs = {} # dict to hold de-ser. json objs
+        dfs = {}
         for p in tqdm(paths, desc='reading json'):
-            data = self._read_json(p)
-            if data[0] in objs.keys():
-                if not isinstance(objs[data[0]], list):
-                    objs[data[0]] = [objs[data[0]]]
-                objs[data[0]].append(data[1])
+            dft = self.read_json(p)
+            if dft[0] in dfs:
+                dfs[dft[0]].append(dft[1])
             else:
-                objs[data[0]] = data[1]
+                dfs[dft[0]] = [dft[1]]
 
-        self._temp = (pklroot == 'temp')
-        self._path = pathlib.Path(tempfile.mkdtemp() if self._temp else pklroot)
+        dfs = {key: pd.concat(dfs[key]) for key in tqdm(dfs.keys(), desc='building dfs')}
+
+        self._temp = (csvroot == 'temp')
+        self.path = pathlib.Path(tempfile.mkdtemp() if self._temp else csvroot)
 
         if self._temp:
-            self._auditor.info(f"Temp directory created at {self._path}")
-        elif not self._path.exists():
-            self._path.mkdir()
-            self._auditor.info(f"Created directory {self._path}")
+            self._auditor.info(f"Temp directory created at {self.path}")
+        elif not self.path.exists():
+            self.path.mkdir()
+            self._auditor.info(f"Created directory {self.path}")
         
-        # This is where json -> pkl conversion happens.
-        # Everything above this point is json objects.
-        #
-        if dev:
-            for obj in tqdm(objs.items(), desc='writing jsons'):
-                p = os.path.join(self._path, f"{obj[0]}.json")
-                with open(p, 'w', encoding='utf-8') as file:
-                    json.dump(obj[1], file)
-                self._auditor.debug(f" Created {p}")
-                self._pkls[obj[0]] = p
-        else:
-            for obj in tqdm(objs.items(), desc='writing pkls'):
-                p = os.path.join(self._path, f"{obj[0]}.pkl")
-                with open(p, 'wb') as file:
-                    pickle.dump(obj[1], file)
-                self._auditor.debug(f" Created {p}")
-                self._pkls[obj[0]] = p
+        for df in tqdm(dfs.items(), desc='writing csvs'):
+            p = os.path.join(self.path, f"{df[0]}.csv")
+            df[1].to_csv(p)
+            self._auditor.debug(f" Created {p}")
+            self.csvs[df[0]] = p
     
-    def _enum_json(self, rootpath:str, ignore_messages:bool) -> list:
+    def enum_json(self, rootpath:str, ignore_messages:bool) -> list:
         """
-        Enumerates JSON files in the specified directory, optionally ignoring the messages folder(s).
+        Enumerates JSON files in the specified directory, optionally ignoring the messages folder.
 
         This method uses the `json_handling.enum_files` function to enumerate all
-        JSON files in the given directory. It can optionally ignore the 'messages'
-        folder(s) to speed up the process. This method also measures the time and
+        JSON files in the given directory. It can optionally ignore the 'inbox'
+        folder to speed up the process. This method also measures the time and
         memory usage during the enumeration process.
 
         Args:
             rootpath (str): The root directory from which JSON files will be enumerated.
-            ignore_messages (bool): Whether to ignore the 'messages' directories.
+            ignore_messages (bool): Whether to ignore the 'inbox' directory.
             logger (logging.Logger): Logger instance for logging information during enumeration.
 
         Returns:
@@ -207,9 +197,9 @@ class JsonReader:
         tracemalloc.stop()
         return paths
     
-    def _read_json(self, path:tuple) -> tuple:
+    def read_json(self, path:tuple) -> tuple:
         """
-        Reads and processes a JSON file from the given path, converting it into a dict/list.
+        Reads and processes a JSON file from the given path, converting it into a DataFrame.
 
         This method attempts to process a JSON file into a pandas DataFrame by using the
         `json_handling.proc_file` function. It measures the processing time and memory usage,
@@ -221,12 +211,18 @@ class JsonReader:
             logger (logging.Logger): Logger instance for logging information during file processing.
 
         Returns:
-            tuple: A tuple containing the name of the obj (as a string) and the obj itself.
+            tuple: A tuple containing the name of the DataFrame (as a string) and the DataFrame itself.
+
+        Raises:
+            TimeoutError: If processing the JSON file takes too long.
         """
         out = None
         start = time.time()
         tracemalloc.start()
-        out = jh.proc_json(path, self._logger) # everything else here is logging
+        try:
+            out = jh.proc_df(path, self._logger)
+        except TimeoutError:
+            self._logger.error(f"Processing file {path[1]} took too long. Skipping...")
         end = time.time()
         c, p = tracemalloc.get_traced_memory()
         fp = os.path.join(path[0], path[1])
@@ -236,107 +232,106 @@ class JsonReader:
         tracemalloc.stop()
         return out
 
-    def get_pkl(self, name:str):
+    def get_csv(self, name:str) -> str:
         """
-        Returns human JSON object from PKL of specified name.
+        Retrieves the path to the CSV file corresponding to the given name.
 
         Args:
-            name (str): The name of the JSB file to retrieve.
+            name (str): The name of the CSV file to retrieve.
 
         Returns:
-            list or dict: The JSON object from the specified JSB file.
+            str: The path to the CSV file.
 
         Raises:
-            KeyError: If no JSB file with the given name exists.
+            KeyError: If no CSV file with the given name exists.
         """
-        if name not in self._pkls.keys():
-            self._logger.error(f"pkl '{name}' does not exist!")
+        if name not in self.csvs.keys():
+            self._logger.error(f"csv '{name}' does not exist!")
             self._logger.error("Please report this error if you believe this file should exist!")
-            raise KeyError(f"pkl '{name}' does not exist!")
+            raise KeyError(f"csv '{name}' does not exist!")
         self._auditor.info(f"Retrieved {name}")
-        path = self._pkls[name]
-        if self._dev:
-            with open(path, 'r', encoding='utf-8') as file:
-                return json.load(file)
-        with open(path, 'rb') as file:
-            return pickle.load(file)
-
+        return self.csvs[name]
+    
     def get_names(self) -> list:
         """
-        Returns a list of the names of all JSB files generated by the JsonReader.
+        Returns a list of the names of all CSV files generated by the JsonReader.
 
-        This method allows for easy access to the names of all JSB files that have
+        This method allows for easy access to the names of all CSV files that have
         been generated, which can be useful for iterating over the files or
         accessing specific ones.
 
         Returns:
-            list: A list of strings, each representing the name of a generated JSON file.
+            list: A list of strings, each representing the name of a generated CSV file.
         """
-        return list(self._pkls.keys())
+        return list(self.csvs.keys())
     
-    def key_info(self, key:str, indent=2) -> str:
+    def key_info(self, key:str) -> str:
         """
-        Provides detailed information about a specific JSB file identified by its key.
+        Provides detailed information about a specific CSV file identified by its key.
 
-        This method reads the JSB file corresponding to the provided key, calculates
+        This method reads the CSV file corresponding to the provided key, calculates
         its shape (number of rows and columns), and its memory usage, and returns
         this information as a formatted string.
 
         Args:
-            key (str): The key (name) of the JSB file to retrieve information for.
+            key (str): The key (name) of the CSV file to retrieve information for.
 
         Returns:
-            str: A formatted string containing details about the JSB file's shape and memory usage.
+            str: A formatted string containing details about the CSV file's shape and memory usage.
 
         Raises:
-            KeyError: If the specified key does not correspond to any existing JSB file.
+            KeyError: If the specified key does not correspond to any existing CSV file.
         """
-        if key not in self._pkls.keys():
+        if key not in self.csvs.keys():
             self._logger.error(f"{key} does not exist")
             raise KeyError(f"{key} does not exist")
         
-        data = self.get_pkl(key)
         self._auditor.info(f"Retrieved info for {key}")
-
-        return f"{key}:\n{' ' * indent}RAM: {sys.getsizeof(data) * 10**-3}KB\n{' ' * indent}structure:{jh.desc_json(data, indent=indent+2)}"
+        df = pd.read_csv(self.csvs[key])
+        sh = df.shape
+        sp = df.memory_usage(deep=True).sum()
+        return f"\n{key}:\n  shape: {sh} RAM: {round(sp * 10**-6, 3)}MB"
     
     def close(self, force:bool=False):
         """
-        Cleans up by deleting temporary PKL files, if applicable.
+        Cleans up by deleting temporary CSV files, if applicable.
 
-        This method is responsible for deleting any temporary JSB files created
+        This method is responsible for deleting any temporary CSV files created
         during the JsonReader's operation. It is typically called when the
         JsonReader instance is no longer needed, to ensure that no unnecessary
         files are left on the filesystem.
         """
         if self._temp or force:
-            shutil.rmtree(self._path)
-            self._auditor.info(f"Deleted directory {self._path}")
-            self._pkls = {}
-            self._path = None
+            shutil.rmtree(self.path)
+            self._auditor.info(f"Deleted directory {self.path}")
+            self.csvs = {}
+            self.path = None
 
     
     def __str__(self) -> str:
         """
-        Returns a string representation of the JsonReader instance, listing all JSBs managed by it.
+        Returns a string representation of the JsonReader instance, listing all CSVs managed by it.
 
-        This method provides an overview of the JSB files that have been generated by this instance,
+        This method provides an overview of the CSV files that have been generated by this instance,
         including their names, shapes, and memory usages. It is useful for quickly understanding
         the state and output of the JsonReader.
 
         Returns:
-            str: A formatted string containing an overview of the JSON files managed by the JsonReader.
+            str: A formatted string containing an overview of the CSV files managed by the JsonReader.
         """
-        out = "--------\nJSONS:"
-        for k in self._pkls.keys():
-            out += f"\n  {self.key_info(k, 4)}"
+        out = "--------\nCSVS:"
+        for k in self.csvs.keys():
+            df = pd.read_csv(self.csvs[k])
+            sh = df.shape
+            sp = df.memory_usage(deep=True).sum()
+            out += f"\n{k}:\n  shape: {sh} RAM: {round(sp * 10**-6, 3)}MB"
         out += "\n--------"
         self._auditor.info("Retrieved info for all keys")
         return out
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog='json_ingest',
-                                     description='Loads and consolidates JSON files',
+                                     description='***DEPRECATED*** Converts JSON data to CSVs',
                                      epilog='(C) 2024 Noah Duggan Erickson, License: GNU AGPL-3.0'
                                      )
     parser.add_argument('-i',  '--in_path',
@@ -344,9 +339,9 @@ if __name__ == "__main__":
                         metavar='/PATH/TO/JSON_ROOT/',
                         help='path to root of JSON data')
     parser.add_argument('-o', '--out_path',
-                        dest='jsb_root', type=str, default='temp',
-                        metavar='/PATH/TO/JSB_ROOT/',
-                        help='path to root of JSB output data (default: temp)')
+                        required=False, dest='csv_root', type=str,
+                        metavar='/WHERE/TO/WRITE/CSVS/', default='temp',
+                        help='directory of where to put outputted csvs')
     parser.add_argument('-m', '--read_messages',
                         action='store_true', dest='m',
                         help="If present, don't skip the messages folder - may take significantly longer to run")
@@ -355,7 +350,6 @@ if __name__ == "__main__":
                         help='Set stdout verbosity level (-v, -vv)')
     parser.add_argument('-d', '--delete', action='store_true', dest='force_delete',
                         help='Delete the output directory after completion (if not temp)')
-    parser.add_argument('-x', help='Dev mode', action='store_true', dest='x')
     args = parser.parse_args()
 
     match args.v:
@@ -370,11 +364,10 @@ if __name__ == "__main__":
 
     ch = logging.StreamHandler()
     logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=level, handlers=[ch])
-    w = max((len(__version__)+3), 20)
-    print("JSON -> PKL INGESTER".center(w))
-    print(f"V. {__version__}".center(w), "\n")
-    reader = JsonReader(jsonroot=args.json_root, pklroot=args.jsb_root,
-                        read_messages=args.m, dev=args.x,
-                        logger=logging.getLogger())
+    print("JSON -> CSV INGESTER")
+    print(f"       V. {__version__}       \n")
+    warn("This script is deprecated and is preserved solely for future developers. Please use the JsonReader class in json_ingest.py instead.", DeprecationWarning, stacklevel=2)
+    reader = JsonReader(jsonroot=args.json_root, csvroot=args.csv_root,
+                        read_messages=args.m, logger=logging.getLogger())
     print(reader)
     reader.close(args.force_delete)


### PR DESCRIPTION
Refer to json_ingest.py for a more detailed list of changes, but here are some of the highlights:
- `JsonReader.get_csv()` renamed to `JsonReader.get_pkl()`, and returns a list/dict instead of a filepath
- `JsonIngest` retains data hierarchical structure via pickles instead of CSV flatsploding
- May be able to experiment with re-adding messages to default config?

Currently only labeling as an `rc` release pending testing and cleaning.